### PR TITLE
Upgrade to latest Provenance Libs

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,18 +6,18 @@ import org.gradle.plugin.use.PluginDependenciesSpec
 
 object Versions {
     const val Arrow = "1.0.1"
-    const val BouncyCastle = "1.68"
+    const val BouncyCastle = "1.70"
     const val Exposed = "0.37.3"
     const val Feign = "10.1.0"
     const val Flyway = "8.0.2"
     const val FrontendHelperPlugin = "6.0.0"
     // Communication with the PbClient requires GRPC to remain versioned in tandem with "ProvenanceClient." Be sure to update this alongside it
-    const val Grpc = "1.42.0"
+    const val Grpc = "1.44.0"
     const val Hikari = "4.0.3"
     const val Jackson = "2.12.5"
     const val JacksonProtobuf = "0.9.12"
     const val JavaX = "1.3.2"
-    const val Kotlin = "1.5.31"
+    const val Kotlin = "1.6.10"
     const val KotlinCoroutines = "1.5.2"
     const val KotlinLogging = "2.1.21"
     const val Kroto = "0.6.1"
@@ -28,10 +28,10 @@ object Versions {
     const val Protobuf = "3.19.1"
     const val ProtobufPlugin = "0.8.16"
     // Both client and proto libraries have coupled versions. Found via inspecting dependencies brought in via client
-    const val ProvenanceClient = "1.0.1"
-    const val ProvenanceHdWallet = "0.1.9"
+    const val ProvenanceClient = "1.0.4"
+    const val ProvenanceHdWallet = "0.1.15"
     // This version is pinned because ProvenanceClient implementation does not bring it along, and matching it allows access to query protos
-    const val ProvenanceProto = "1.7.0-0.0.2"
+    const val ProvenanceProto = "1.8.0-rc7"
     const val ProvenanceScope = "0.4.6"
     const val Scarlet = "0.1.11"
     const val SpringBoot = "2.5.6"
@@ -111,7 +111,7 @@ object Dependencies {
     object Provenance {
         val ProvenanceGrpcClient = DependencySpec("io.provenance.client:pb-grpc-client-kotlin", Versions.ProvenanceClient)
         val ProvenanceHdWallet = DependencySpec("io.provenance.hdwallet:hdwallet", Versions.ProvenanceHdWallet)
-        val ProvenanceProto = DependencySpec("io.provenance.protobuf:pb-proto-java", Versions.ProvenanceProto)
+        val ProvenanceProto = DependencySpec("io.provenance:proto-kotlin", Versions.ProvenanceProto)
         val ScopeSdk = DependencySpec("io.provenance.scope:sdk", Versions.ProvenanceScope)
         val ScopeUtil = DependencySpec("io.provenance.scope:util", Versions.ProvenanceScope)
     }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
 // Let gradle know that the integration test directory is for test runnin'
 sourceSets {
     create("integrationTest") {
-        compileClasspath += main.get().output + test.get().output + configurations.testCompileClasspath + configurations.testCompileOnly
+        compileClasspath += main.get().output + test.get().output + configurations.testCompileClasspath
         runtimeClasspath += main.get().output + test.get().output + compileClasspath
         java.srcDir("integrationTest")
     }

--- a/server/src/main/kotlin/io/provenance/invoice/config/provenance/ProvenanceConfig.kt
+++ b/server/src/main/kotlin/io/provenance/invoice/config/provenance/ProvenanceConfig.kt
@@ -1,6 +1,6 @@
 package io.provenance.invoice.config.provenance
 
-import io.provenance.client.PbClient
+import io.provenance.client.grpc.PbClient
 import io.provenance.invoice.config.app.Qualifiers
 import io.provenance.invoice.config.app.ServiceProperties
 import io.provenance.invoice.util.provenance.ProvenanceAccountDetail

--- a/server/src/main/kotlin/io/provenance/invoice/services/ProvenanceQueryService.kt
+++ b/server/src/main/kotlin/io/provenance/invoice/services/ProvenanceQueryService.kt
@@ -7,10 +7,11 @@ import cosmos.base.abci.v1beta1.Abci.TxResponse
 import cosmos.tx.v1beta1.ServiceOuterClass.BroadcastMode
 import cosmos.tx.v1beta1.TxOuterClass.TxBody
 import cosmwasm.wasm.v1.Tx.MsgExecuteContract
-import io.provenance.client.PbClient
 import io.provenance.client.grpc.BaseReq
 import io.provenance.client.grpc.BaseReqSigner
 import io.provenance.client.grpc.GasEstimate
+import io.provenance.client.grpc.PbClient
+import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.invoice.config.provenance.ObjectStore
 import io.provenance.invoice.config.provenance.ProvenanceProperties
 import io.provenance.invoice.domain.provenancetx.OracleApproval
@@ -63,7 +64,7 @@ class ProvenanceQueryService(
      * On a failure, wraps the response error in an OracleApprovalException for upstream handling.
      */
     private fun getOracleAccount(logPrefix: String): Either<OracleApprovalException, BaseAccount> = Either
-        .catch { pbClient.getBaseAccount(objectStore.oracleAccountDetail.bech32Address) }
+        .catch { pbClient.authClient.getBaseAccount(objectStore.oracleAccountDetail.bech32Address) }
         .mapLeftToOracleFailure("$logPrefix Failed to fetch base account for oracle address [${objectStore.oracleAccountDetail.bech32Address}]. Marking invoice with approval failure")
 
     /**

--- a/server/src/main/kotlin/io/provenance/invoice/util/provenance/AccountSigner.kt
+++ b/server/src/main/kotlin/io/provenance/invoice/util/provenance/AccountSigner.kt
@@ -5,10 +5,8 @@ import cosmos.crypto.secp256k1.Keys
 import io.provenance.client.grpc.Signer
 import io.provenance.hdwallet.ec.PrivateKey
 import io.provenance.hdwallet.ec.PublicKey
-import io.provenance.hdwallet.ec.toECKeyPair
-import io.provenance.hdwallet.ec.toECPrivateKey
-import io.provenance.hdwallet.ec.toECPublicKey
-import io.provenance.hdwallet.ec.toJavaPrivateKey
+import io.provenance.hdwallet.ec.extensions.toECPrivateKey
+import io.provenance.hdwallet.ec.extensions.toJavaECPrivateKey
 import io.provenance.hdwallet.signer.BCECSigner
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.encryption.util.toKeyPair
@@ -24,7 +22,7 @@ class AccountSigner(
     override fun pubKey(): Keys.PubKey =
         Keys.PubKey.newBuilder().setKey(ByteString.copyFrom(publicKey.compressed())).build()
 
-    override fun sign(data: ByteArray): ByteArray = BCECSigner().sign(privateKey, data.sha256()).encodeAsBTC()
+    override fun sign(data: ByteArray): ByteArray = BCECSigner().sign(privateKey, data.sha256()).encodeAsBTC().toByteArray()
 
     companion object {
         fun fromAccountDetail(
@@ -45,7 +43,7 @@ class AccountSigner(
         fun fromWalletPrivateKey(
             privateKey: PrivateKey,
             mainNet: Boolean,
-        ): AccountSigner = privateKey.toJavaPrivateKey().toKeyPair().let { keyPair ->
+        ): AccountSigner = privateKey.toJavaECPrivateKey().toKeyPair().let { keyPair ->
             AccountSigner(
                 address = keyPair.public.getAddress(mainNet),
                 publicKey = privateKey.toPublicKey(),

--- a/server/src/test/kotlin/io/provenance/invoice/util/provenance/TestAccountSigner.kt
+++ b/server/src/test/kotlin/io/provenance/invoice/util/provenance/TestAccountSigner.kt
@@ -1,7 +1,7 @@
 package io.provenance.invoice.util.provenance
 
 import helper.assertSucceeds
-import io.provenance.hdwallet.ec.toECPrivateKey
+import io.provenance.hdwallet.ec.extensions.toECPrivateKey
 import io.provenance.scope.encryption.ecies.ECUtils
 import org.junit.jupiter.api.Test
 import org.testcontainers.shaded.com.google.common.io.BaseEncoding


### PR DESCRIPTION
This change tweaks versions in the source to match the latest updates to the provenance grpc client libraries.  This introduces message fees to transactions - the old libs do not add the message fees, so transactions executed by the app would fail to charge the correct amount in various circumstances.  Fee calculation is bundled in `pbClient.estimateTx` so the underlying libs just needed tweaked for this stuff to automagically work.

The following updates have been made:
- Update Bouncycastle to 1.70 (same as the provenance lib)
- Update to Kotlin 1.6.10 (same as the provenance lib)
- Update grpc to 1.44.0 (same as the provenance lib)
- Update to provenance client 1.0.4 (the core provider of these lib changes)
- Update to use provenance proto resource 1.8.0-rc7 - this moved from `io.provenance.protobuf:pb-proto-java` to `io.provenance:proto-kotlin`