### PR TITLE
Add payable type as default to the onboarding call

### DIFF
--- a/server/src/main/kotlin/io/provenance/invoice/clients/OnboardingApiClient.kt
+++ b/server/src/main/kotlin/io/provenance/invoice/clients/OnboardingApiClient.kt
@@ -23,8 +23,8 @@ interface OnboardingApiClient {
         "${AppHeaders.ADDRESS}: {address}",
         "${AppHeaders.PUBLIC_KEY}: {publicKey}",
     )
-    @RequestLine("POST /api/v1/asset?permissionAssetManager=true")
-    fun generateOnboarding(
+    @RequestLine("POST /api/v1/asset?permissionAssetManager=true&type=payable")
+    fun onboardPayable(
         @Param("address") address: String,
         @Param("publicKey") publicKey: String,
         asset: Asset,

--- a/server/src/main/kotlin/io/provenance/invoice/services/AssetOnboardingService.kt
+++ b/server/src/main/kotlin/io/provenance/invoice/services/AssetOnboardingService.kt
@@ -27,7 +27,7 @@ class AssetOnboardingService(
         // use the oracle's public key in the call.  Sending the wallet's address ensures that the wallet owns the
         // newly-created scope, and sending the oracle's public key allows the oracle (an account made specifically for
         // this application) can query object store for the asset, allowing us to validate the invoice
-        return onboardingApi.generateOnboarding(
+        return onboardingApi.onboardPayable(
             address = walletAddress,
             publicKey = oracleAccountDetail.encodedPublicKey,
             asset = asset,

--- a/server/src/main/kotlin/io/provenance/invoice/services/mock/MockOnboardingApiClient.kt
+++ b/server/src/main/kotlin/io/provenance/invoice/services/mock/MockOnboardingApiClient.kt
@@ -16,7 +16,7 @@ class MockOnboardingApiClient : OnboardingApiClient {
         logger.warn("App starting with simulated onboarding api client")
     }
 
-    override fun generateOnboarding(
+    override fun onboardPayable(
         address: String,
         publicKey: String,
         asset: Asset


### PR DESCRIPTION
All invoices are "payable" asset types, and should receive the correct scope specification from service-asset-onboarding.  Appending this "type" will cause asset-onboarding to query the asset classification smart contract and find the correct type